### PR TITLE
Add missing shell types to customize value

### DIFF
--- a/project-shells.el
+++ b/project-shells.el
@@ -97,7 +97,7 @@ function (symbol or lambda)."
 		       :value-type (list :tag "Shell setup"
 					 (string :tag "Name")
 					 (choice :tag "Directory" string (const ask))
-					 (choice :tag "Type" (const term) (const shell))
+					 (choice :tag "Type" (const term) (const shell) (const eshell) (const vterm))
 					 (choice :tag "Function" (const nil) function)))))
 
 (defcustom project-shells-default-init-func 'project-shells-init-sh


### PR DESCRIPTION
I was looking through and spotted this minor omission from the customize setup for the variable `project-shells-setup` 