### PR TITLE
Add setting of keybindings for vterms

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,6 +66,7 @@ terminal, eshell buffers via customize the following variables,
 #+BEGIN_SRC emacs-lisp
 project-shells-term-keys
 project-shells-eshell-keys
+project-shells-vterm-keys
 #+END_SRC
 
 To create or switch to the global shells, you need to use position

--- a/project-shells.el
+++ b/project-shells.el
@@ -111,6 +111,14 @@ be bound in a non-global keymap."
   :group 'project-shells
   :type '(repeat string))
 
+(defcustom project-shells-vterm-keys nil
+  "Keys used to create vterm buffers.
+
+One vterm will be created for each key.  Usually these key will
+be bound in a non-global keymap."
+  :group 'project-shells
+  :type '(repeat string))
+
 (defcustom project-shells-term-keys '("-")
   "Keys used to create terminal buffers.
 
@@ -298,6 +306,7 @@ name, and the project root directory."
 		    ((cl-third shell-info))
 		    ((member key project-shells-term-keys) 'term)
 		    ((member key project-shells-eshell-keys) 'eshell)
+		    ((member key project-shells-vterm-keys) 'vterm)
 		    (t 'shell)))
 	     (dir (or (cl-second shell-info) proj-root))
 	     (func (cl-fourth shell-info))


### PR DESCRIPTION
I want to be able to create vterms because they are fast and more functional than term buffers.  I have extended the existing pattern of allowing a list of strings be used to define a list of keys to create vterms.